### PR TITLE
Add project recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default[:boilerplate][:recipes] =
   case node[:platform]
   when 'debian', 'ubuntu'
     %w(
-      apt_fast apt_packages gem_packages pip_packages npm_packages bower_packages
+      apt_fast apt_packages project gem_packages pip_packages npm_packages bower_packages
       apache2 mysql redmine
     )
   else


### PR DESCRIPTION
gem_packagesレシピの前に定義しないと、Gemfileが参照されないです。
動作確認したバージョンは0.5.10です。
masterブランチはchef_dkレシピが追加されてますが、動作未確認です。
